### PR TITLE
Issue#1 - gradle5_1 - lagging aspectj plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,13 @@
 buildscript {
     repositories {
         maven {
-            url "https://maven.eveoh.nl/content/repositories/releases"
+          url 'https://plugins.gradle.org/m2/'
         }
     }
 
     dependencies {
-        classpath 'nl.eveoh:gradle-aspectj:1.6'
+      classpath 'gradle.plugin.de:AspectjGradlePlugin:0.0.3'
     }
-}
-
-plugins {
 }
 
 project.ext {
@@ -24,7 +21,7 @@ ext {
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'aspectj'
+apply plugin: 'aspectj.AspectjGradlePlugin'
 apply plugin: 'application'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 project.ext {
-    aspectjVersion = '1.8.10'
+    aspectjVersion = '1.9.4'
 }
 
 ext {


### PR DESCRIPTION
Addresses #1 

* Update aspectj gradle plugin to a version that supports
  gradle > 5.0.
  * the version updated does not support gradle > 6.0, but
    none of the plugins listed on plugins.gradle.org at this
    time do support gradle > 6.0 .
* Update aspectjVersion from 1.8 -> 1.9 .

Tested w/ gradle  4.10.3, 5.1, 6.0 (fails). There are currently no gradle-aspectj plugins supporting gradle 6.0+ .